### PR TITLE
ci(e2e): scoper le workflow aux tests mock et exclure les tests carte

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -41,4 +41,9 @@ jobs:
           profile: pixel_6
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: flutter test integration_test/ --timeout 300s
+          # Scope volontairement restreint :
+          # - `scenarios/` : tests E2E mock, tournent sur l'emulator CI sans dep externe
+          # - exclure `scenarios_real/` : nécessitent un vrai serveur GeoNature inaccessible en CI
+          # - exclure tag `map` : tests qui rendent flutter_map → requêtes tile.openstreetmap.org
+          #   qui échouent sur l'emulator GH Actions (Network is unreachable post-test)
+          script: flutter test integration_test/scenarios/ --exclude-tags=map --timeout 300s

--- a/integration_test/scenarios/site_geometry_e2e_test.dart
+++ b/integration_test/scenarios/site_geometry_e2e_test.dart
@@ -1,3 +1,6 @@
+@Tags(['map'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gn_mobile_monitoring/domain/model/base_site.dart';
@@ -15,6 +18,13 @@ import '../helpers/test_data_seeder.dart';
 /// `SiteFormWrapper` → `LocationPreviewHeader` → `LocationPickerPage` sans
 /// dépendre de la navigation Home → Module → Site qui est déjà testée par
 /// ailleurs. La stabilité prime sur la répétition de la chaîne complète.
+///
+/// **Tagué `map`** : ces tests rendent `flutter_map` avec un `TileLayer` qui
+/// fetch les tuiles OSM en réseau. En CI (GitHub Actions emulator), le
+/// réseau vers `tile.openstreetmap.org` est inaccessible et les `fetch` en
+/// cours après la fin du test émettent des `SocketException` qui font
+/// remonter un échec post-completion. Sur un device physique avec réseau
+/// ces tests passent ; la CI les exclut via `--exclude-tags=map`.
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 


### PR DESCRIPTION
Deux corrections sur le workflow E2E suite aux échecs du run https://github.com/RNF-SI/gn_mobile_monitoring/actions/runs/24412381622 qui avait reporté 10 échecs alors que la suite passe localement sur Pixel.

**1. Exclure `integration_test/scenarios_real/` du workflow** Ces scénarios sont écrits pour tourner contre un vrai serveur GeoNature (voir `docs/E2E_REAL_API_TESTS.md`), avec `.env.test` + `adb reverse`. En CI sans serveur cible, les 9 tests échouent systématiquement avec `Connection refused`. Le workflow ne devait pas les invoquer.

Avant : `flutter test integration_test/ --timeout 300s`
Après : `flutter test integration_test/scenarios/ --exclude-tags=map --timeout 300s`

**2. Tagger `site_geometry_e2e_test.dart` avec `@Tags(['map'])`** Ces scénarios pompent `LocationPreviewHeader` et `LocationPickerPage` qui rendent un `flutter_map` avec `TileLayer(urlTemplate: tile.openstreetmap.org)`. Sur le Pixel physique les tuiles chargent sans souci, mais l'emulator GitHub Actions ne résout pas `tile.openstreetmap.org` — les `HttpClient` fetch renvoient `SocketException: Network is unreachable (errno 101)` APRÈS la fin du test, ce qui fait remonter un `(failed after test completion)`. Le test logique lui-même passe (les assertions sur "Ligne tracée" / "3 sommet(s)" réussissent).

Le tag permet de :
- exclure le test en CI avec `--exclude-tags=map`
- continuer à le lancer localement sur un device avec réseau
- éviter de refactorer l'injection de `TileProvider` juste pour la CI

Les 3 autres tests qui pompent `SiteFormPage` (site_lifecycle_e2e_test.dart) ne sont pas concernés : ils seedent des sites sans `geom`, donc `LocationPreviewHeader` affiche le placeholder "Pas de géométrie" sans instancier de `FlutterMap`.