### PR TITLE
docs: rendre le code de version plus visible + porter VERSIONS.md sur main

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ GN Mobile Monitoring est un portage mobile du module monitoring de GeoNature. Il
 
 ## Compatibilité des versions
 
-| Version app mobile | GeoNature core | Version minimale monitoring (module serveur) |
-|---|---|---|
-| `v1.0.0-geonature-2.17` | 2.17.x | 1.2.6 |
-| `v1.0.0-geonature-2.16` | 2.16.x | 1.2.0 |
+| Version app mobile | GeoNature core | Monitoring serveur (min) | Code de version |
+|---|---|---|---|
+| `v1.0.0-geonature-2.17` | 2.17.x | 1.2.6 | `1` |
+
+Le **code de version** est la valeur à renseigner côté admin GeoNature (voir [Déploiement](#-déploiement-et-mise-à-jour)). Pour l'historique complet des releases, voir [`docs/VERSIONS.md`](./docs/VERSIONS.md).
 
 L'application vérifie automatiquement la version du module monitoring sur le serveur avant chaque téléchargement de module. Si la version est inférieure à la version minimale requise, le téléchargement est bloqué avec un message explicatif.
 
@@ -145,7 +146,9 @@ Pour que les utilisateurs soient notifiés des mises à jour, l'administrateur d
    | Code application | `MONITORING` |
    | Chemin relatif de l'APK | `monitoring/monitoring.apk` |
    | Nom du paquet | `fr.geonature.monitoring` |
-   | Code de version | Le buildNumber de la version (ex: `2`) |
+   | Code de version | Valeur publiée avec chaque release — voir le tableau [Compatibilité des versions](#compatibilité-des-versions) ou [`docs/VERSIONS.md`](./docs/VERSIONS.md). Pour `v1.0.0-geonature-2.17`, c'est `1`. |
+
+   > ⚠️ **Code de version** : ne pas confondre avec le nom de version (`1.0.0`). C'est un entier strictement croissant, fixé à la compilation (buildNumber de `pubspec.yaml`), que l'admin doit saisir tel quel. L'app ne propose une mise à jour que si la valeur admin est **strictement supérieure** à celle de l'APK installé.
 
 4. **Mettre à jour** : lors d'une nouvelle version, remplacer l'APK et incrémenter le **Code de version** dans l'admin.
 

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -1,0 +1,47 @@
+# Historique des versions publiées
+
+Ce document liste les versions de l'app mobile publiées officiellement, avec les informations nécessaires au déploiement côté serveur GeoNature.
+
+> 💡 **Tu cherches juste la valeur à saisir dans le champ « Code de version » de l'admin GeoNature ?** Elle est publiée pour chaque release dans la section [Versions](#versions) ci-dessous (colonne **Code de version**). Pour la dernière release `v1.0.0-geonature-2.17`, c'est `1`.
+
+## Comment utiliser ce document
+
+Chaque entrée décrit une release :
+
+- **Tag** : le tag Git + GitHub Release qui contient l'APK.
+- **Code de version** : valeur à saisir dans **Administration > Autres > Applications mobiles** du serveur GeoNature, champ « Code de version ». Correspond au `buildNumber` de `pubspec.yaml` (partie après le `+`). Le serveur ne notifie l'utilisateur d'une mise à jour que si le code distant est **strictement supérieur** au code installé.
+- **GeoNature core** : lignes majeures GeoNature sur lesquelles l'APK est validé.
+- **Module `gn_module_monitoring`** : version minimale du module serveur. Vérifiée automatiquement par l'app avant chaque téléchargement de module.
+
+## Versions
+
+### v1.0.0-geonature-2.17
+
+- **Date** : 2026-04-14
+- **Code de version** : `1`
+- **GeoNature core** : 2.17.x
+- **Module `gn_module_monitoring`** : ≥ 1.2.6
+- **Release GitHub** : [v1.0.0-geonature-2.17](https://github.com/RNF-SI/gn_mobile_monitoring/releases/tag/v1.0.0-geonature-2.17)
+- **Branche de support** : `support/geonature-2.17`
+
+Première release stable de l'app mobile monitoring. Saisie hors-ligne des sites, groupes de sites, visites et observations, avec géométries Point / LineString / Polygon éditables sur carte et synchronisation manuelle vers GeoNature.
+
+### v1.0.0-geonature-2.16
+
+- **Date** : 2026-04-13
+- **Code de version** : `1`
+- **GeoNature core** : 2.16.x
+- **Module `gn_module_monitoring`** : ≥ 1.2.0
+- **Tag Git uniquement** : [v1.0.0-geonature-2.16](https://github.com/RNF-SI/gn_mobile_monitoring/releases/tag/v1.0.0-geonature-2.16) (pas d'APK publié — voir note ci-dessous)
+- **Branche de support** : `support/geonature-2.16`
+
+Tag figeant l'état du code avant la bascule `develop` vers la compat GeoNature 2.17. Aucune évolution majeure de code entre ce tag et `v1.0.0-geonature-2.17` ne remet en cause la compatibilité avec un serveur GeoNature 2.16 : les changements apportés sont soit client-side (picker de géométrie, calcul de distance), soit des correctifs de synchronisation qui bénéficient aux deux lignes majeures. Un serveur en GeoNature 2.16.x peut utiliser `v1.0.0-geonature-2.17` sans incompatibilité identifiée à ce jour (non testé en conditions réelles contre une instance 2.16).
+
+## Bonnes pratiques pour une future release
+
+1. Incrémenter `version:` dans `pubspec.yaml` **y compris le `buildNumber`** (partie après `+`). Si la version installée chez un utilisateur est `1.0.0+1` et que la nouvelle release reste à `1.0.0+1`, l'update in-app ne sera **pas** proposée.
+2. Mettre à jour la matrice de compat dans `README.md` et ce document.
+3. Publier l'APK en tant que **GitHub Release** (pas seulement un tag Git), avec :
+   - Nom de l'asset : `monitoring-v<X.Y.Z>-geonature-<M.m>.apk`
+   - Rappel du code de version dans la description.
+4. Communiquer aux admins GeoNature le nouveau code de version à saisir côté admin.


### PR DESCRIPTION
## Contexte

Retour utilisateur sur la release [`v1.0.0-geonature-2.17`](https://github.com/RNF-SI/gn_mobile_monitoring/releases/tag/v1.0.0-geonature-2.17) : la valeur à saisir dans le champ **« Code de version »** côté admin GeoNature n'était pas trouvable facilement (ni dans la release, ni dans la doc).

## Résumé

- `README.md` :  Déploiement : la ligne « Code de version » du tableau admin donne maintenant la valeur concrète pour la release courante (`1`) et pointe vers le tableau de compatibilité + `docs/VERSIONS.md`. Ajout d'un callout qui explique la différence avec le nom de version (`1.0.0` ≠ `1`) et la règle « strictement supérieur ».
- `docs/VERSIONS.md` : ajout d'un callout en tête donnant directement la valeur pour la dernière release.
- Port du document `docs/VERSIONS.md` depuis `feat/multi-provider-auth` (où il vivait sans jamais avoir été mergé sur `main`), + colonne « Code de version » dans le tableau de compat du README.

## À noter

Les commits doc en amont (`2ff1158`, `5c85d3b`) sur `feat/multi-provider-auth` retiraient aussi la ligne `v1.0.0-geonature-2.16` du tableau de compat du README (raison : pas d'APK publié pour ce tag). Cette PR préserve ce choix, l'info 2.16 reste présente dans `docs/VERSIONS.md` avec la note explicative.

## Test plan

- [x] Preview Markdown du README et de `docs/VERSIONS.md` sur GitHub
- [ ] Vérifier que les ancres `#compatibilité-des-versions` et `#-déploiement-et-mise-à-jour` résolvent bien après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)