### PR TITLE
docs: aligner les mentions avec la release v1.0.0 (nom ≠ tag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GN Mobile Monitoring est un portage mobile du module monitoring de GeoNature. Il
 
 | Version app mobile | GeoNature core | Monitoring serveur (min) | Code de version |
 |---|---|---|---|
-| `v1.0.0-geonature-2.17` | 2.17.x | 1.2.6 | `1` |
+| `v1.0.0` | ≥ 2.16.x | 1.2.6 | `1` |
 
 Le **code de version** est la valeur à renseigner côté admin GeoNature (voir [Déploiement](#-déploiement-et-mise-à-jour)). Pour l'historique complet des releases, voir [`docs/VERSIONS.md`](./docs/VERSIONS.md).
 
@@ -146,7 +146,7 @@ Pour que les utilisateurs soient notifiés des mises à jour, l'administrateur d
    | Code application | `MONITORING` |
    | Chemin relatif de l'APK | `monitoring/monitoring.apk` |
    | Nom du paquet | `fr.geonature.monitoring` |
-   | Code de version | Valeur publiée avec chaque release — voir le tableau [Compatibilité des versions](#compatibilité-des-versions) ou [`docs/VERSIONS.md`](./docs/VERSIONS.md). Pour `v1.0.0-geonature-2.17`, c'est `1`. |
+   | Code de version | Valeur publiée avec chaque release — voir le tableau [Compatibilité des versions](#compatibilité-des-versions) ou [`docs/VERSIONS.md`](./docs/VERSIONS.md). Pour la release `v1.0.0`, c'est `1`. |
 
    > ⚠️ **Code de version** : ne pas confondre avec le nom de version (`1.0.0`). C'est un entier strictement croissant, fixé à la compilation (buildNumber de `pubspec.yaml`), que l'admin doit saisir tel quel. L'app ne propose une mise à jour que si la valeur admin est **strictement supérieure** à celle de l'APK installé.
 

--- a/docs/FEATURES_OVERVIEW.md
+++ b/docs/FEATURES_OVERVIEW.md
@@ -4,7 +4,7 @@ Ce document présente les capacités et limitations de l'application mobile GeoN
 
 > 💡 Pour la documentation technique détaillée des expressions JavaScript, voir [JAVASCRIPT_EXPRESSIONS.md](JAVASCRIPT_EXPRESSIONS.md)
 
-## 🆕 Dernières Améliorations (Avril 2026 — `v1.0.0-geonature-2.17`)
+## 🆕 Dernières Améliorations (Avril 2026 — `v1.0.0`)
 
 ### Saisie et visualisation de géométrie de site
 L'app gère désormais la création et l'édition de géométries de site directement depuis le mobile — fini le besoin de passer par l'interface web pour tracer une aire.
@@ -470,13 +470,13 @@ Pour mettre à jour le tableau après avoir testé un module :
 
 ---
 
-**Dernière mise à jour** : avril 2026 (release `v1.0.0-geonature-2.17`)
+**Dernière mise à jour** : avril 2026 (release `v1.0.0`)
 **Version de l'application** : Flutter 3.38.4 / Dart 3.10.3
 **Architecture** : Clean Architecture avec Riverpod
 
 ## 📋 Historique des Changements
 
-### Release `v1.0.0-geonature-2.17` — avril 2026
+### Release `v1.0.0` — avril 2026
 - ✅ Picker de géométrie site `LineString`/`Polygon` plein écran avec validation des polygones auto-intersectés
 - ✅ Aperçu carte en lecture seule sur la page de détail d'un site (`LocationPreviewHeader`)
 - ✅ Calcul de distance GPS → site pour tous les types `Multi*` (issue #154)

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -2,46 +2,50 @@
 
 Ce document liste les versions de l'app mobile publiées officiellement, avec les informations nécessaires au déploiement côté serveur GeoNature.
 
-> 💡 **Tu cherches juste la valeur à saisir dans le champ « Code de version » de l'admin GeoNature ?** Elle est publiée pour chaque release dans la section [Versions](#versions) ci-dessous (colonne **Code de version**). Pour la dernière release `v1.0.0-geonature-2.17`, c'est `1`.
+> 💡 **Tu cherches juste la valeur à saisir dans le champ « Code de version » de l'admin GeoNature ?** Elle est publiée pour chaque release dans la section [Versions](#versions) ci-dessous (colonne **Code de version**). Pour la dernière release `v1.0.0`, c'est `1`.
 
 ## Comment utiliser ce document
 
 Chaque entrée décrit une release :
 
-- **Tag** : le tag Git + GitHub Release qui contient l'APK.
+- **Nom de la release** : tel qu'affiché sur GitHub. Ne coïncide pas forcément avec le tag Git (ex. release `v1.0.0` publiée sur le tag `v1.0.0-geonature-2.17`).
+- **Tag Git** : identifiant immuable de la release, utilisé dans les URLs GitHub et pour nommer l'APK attaché.
 - **Code de version** : valeur à saisir dans **Administration > Autres > Applications mobiles** du serveur GeoNature, champ « Code de version ». Correspond au `buildNumber` de `pubspec.yaml` (partie après le `+`). Le serveur ne notifie l'utilisateur d'une mise à jour que si le code distant est **strictement supérieur** au code installé.
 - **GeoNature core** : lignes majeures GeoNature sur lesquelles l'APK est validé.
 - **Module `gn_module_monitoring`** : version minimale du module serveur. Vérifiée automatiquement par l'app avant chaque téléchargement de module.
 
 ## Versions
 
-### v1.0.0-geonature-2.17
+### v1.0.0
 
 - **Date** : 2026-04-14
 - **Code de version** : `1`
-- **GeoNature core** : 2.17.x
+- **GeoNature core** : ≥ 2.16.x
 - **Module `gn_module_monitoring`** : ≥ 1.2.6
-- **Release GitHub** : [v1.0.0-geonature-2.17](https://github.com/RNF-SI/gn_mobile_monitoring/releases/tag/v1.0.0-geonature-2.17)
+- **Tag Git** : [`v1.0.0-geonature-2.17`](https://github.com/RNF-SI/gn_mobile_monitoring/releases/tag/v1.0.0-geonature-2.17)
+- **APK** : `monitoring-v1.0.0-geonature-2.17.apk`
 - **Branche de support** : `support/geonature-2.17`
 
-Première release stable de l'app mobile monitoring. Saisie hors-ligne des sites, groupes de sites, visites et observations, avec géométries Point / LineString / Polygon éditables sur carte et synchronisation manuelle vers GeoNature.
+Première release stable de l'app mobile monitoring. Saisie hors-ligne des sites, groupes de sites, visites et observations, avec géométries Point / LineString / Polygon éditables sur carte et synchronisation manuelle vers GeoNature. Le suffixe `-geonature-2.17` du tag est un héritage du processus de build — la release elle-même est validée pour GeoNature ≥ 2.16.x.
 
-### v1.0.0-geonature-2.16
+### v1.0.0-geonature-2.16 (snapshot interne)
 
 - **Date** : 2026-04-13
 - **Code de version** : `1`
 - **GeoNature core** : 2.16.x
 - **Module `gn_module_monitoring`** : ≥ 1.2.0
-- **Tag Git uniquement** : [v1.0.0-geonature-2.16](https://github.com/RNF-SI/gn_mobile_monitoring/releases/tag/v1.0.0-geonature-2.16) (pas d'APK publié — voir note ci-dessous)
+- **Tag Git uniquement** : [`v1.0.0-geonature-2.16`](https://github.com/RNF-SI/gn_mobile_monitoring/releases/tag/v1.0.0-geonature-2.16) (pas d'APK publié — voir note ci-dessous)
 - **Branche de support** : `support/geonature-2.16`
 
-Tag figeant l'état du code avant la bascule `develop` vers la compat GeoNature 2.17. Aucune évolution majeure de code entre ce tag et `v1.0.0-geonature-2.17` ne remet en cause la compatibilité avec un serveur GeoNature 2.16 : les changements apportés sont soit client-side (picker de géométrie, calcul de distance), soit des correctifs de synchronisation qui bénéficient aux deux lignes majeures. Un serveur en GeoNature 2.16.x peut utiliser `v1.0.0-geonature-2.17` sans incompatibilité identifiée à ce jour (non testé en conditions réelles contre une instance 2.16).
+Tag figeant l'état du code avant la bascule `develop` vers la compat GeoNature 2.17. Aucune évolution majeure de code entre ce tag et la release `v1.0.0` ne remet en cause la compatibilité avec un serveur GeoNature 2.16 : les changements apportés sont soit client-side (picker de géométrie, calcul de distance), soit des correctifs de synchronisation qui bénéficient aux deux lignes majeures. Un serveur en GeoNature 2.16.x peut utiliser l'APK de la release `v1.0.0` sans incompatibilité identifiée à ce jour (non testé en conditions réelles contre une instance 2.16).
 
 ## Bonnes pratiques pour une future release
 
 1. Incrémenter `version:` dans `pubspec.yaml` **y compris le `buildNumber`** (partie après `+`). Si la version installée chez un utilisateur est `1.0.0+1` et que la nouvelle release reste à `1.0.0+1`, l'update in-app ne sera **pas** proposée.
 2. Mettre à jour la matrice de compat dans `README.md` et ce document.
 3. Publier l'APK en tant que **GitHub Release** (pas seulement un tag Git), avec :
-   - Nom de l'asset : `monitoring-v<X.Y.Z>-geonature-<M.m>.apk`
+   - Tag Git : `v<X.Y.Z>-geonature-<M.m>` (convention interne de build)
+   - Nom de la release : libre (ex. `v<X.Y.Z>`), à choisir selon la communication voulue côté utilisateur
+   - Nom de l'asset APK : `monitoring-v<X.Y.Z>-geonature-<M.m>.apk`
    - Rappel du code de version dans la description.
 4. Communiquer aux admins GeoNature le nouveau code de version à saisir côté admin.


### PR DESCRIPTION
## Contexte

La release GitHub publiée sur le tag `v1.0.0-geonature-2.17` a été renommée en **`v1.0.0`** pour refléter sa compatibilité élargie (≥ GeoNature 2.16.x) et éviter de lier le nom d'affichage à une version GeoNature précise. Le tag Git, lui, reste inchangé (convention de build + URLs stables + filename APK immuable).

Plusieurs pages doc faisaient encore référence à l'ancien nom. Cette PR les aligne.

## Résumé des changements

- **`README.md`** :
  - Tableau « Compatibilité des versions » : `v1.0.0-geonature-2.17 | 2.17.x` → `v1.0.0 | ≥ 2.16.x`
  - Callout « Code de version » § Déploiement : « Pour \`v1.0.0-geonature-2.17\`, c'est \`1\` » → « Pour la release \`v1.0.0\`, c'est \`1\` »

- **`docs/VERSIONS.md`** :
  - Callout en tête utilise le nouveau nom
  - Entrée principale renommée `v1.0.0` ; le tag Git (`v1.0.0-geonature-2.17`) reste cité comme un champ séparé avec lien vers la page release, et le filename APK est cité explicitement
  - Entrée `v1.0.0-geonature-2.16` renommée en « snapshot interne » pour qu'il n'y ait plus d'ambiguïté avec une release publiée
  - Section « Bonnes pratiques » : explicite que le **nom** de la release est libre, seul le **tag** suit la convention interne

- **`docs/FEATURES_OVERVIEW.md`** : trois occurrences du titre (entête, footer, historique) mises à jour.

## Ce qui n'a PAS bougé (intentionnel)

- Le tag Git `v1.0.0-geonature-2.17` (immuable, et les URLs \`releases/tag/v1.0.0-geonature-2.17\` continuent de marcher)
- Le filename APK `monitoring-v1.0.0-geonature-2.17.apk` (asset déjà publié)
- L'entrée `v1.0.0-geonature-2.16` elle-même (tag distinct, non renommé)

## Test plan

- [x] \`grep -r v1.0.0-geonature-2.17\` : seules les 3 occurrences voulues (explication nom↔tag, URL du tag, filename APK) subsistent dans \`docs/VERSIONS.md\`
- [ ] Preview Markdown de \`README.md\`, \`docs/VERSIONS.md\`, \`docs/FEATURES_OVERVIEW.md\` sur la PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)