### PR TITLE
docs: expliciter que la colonne "Code de version" est le champ admin GeoNature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ GN Mobile Monitoring est un portage mobile du module monitoring de GeoNature. Il
 
 ## Compatibilité des versions
 
-| Version app mobile | GeoNature core | Monitoring serveur (min) | Code de version |
+| Version app mobile | GeoNature core | Monitoring serveur (min) | Code de version (à saisir côté admin GeoNature) |
 |---|---|---|---|
 | `v1.0.0` | ≥ 2.16.x | 1.2.6 | `1` |
 


### PR DESCRIPTION
## Contexte

Retour utilisateur (même issue que PRs #162 / #164) : la colonne « Code de version » du tableau de compat devrait annoncer plus clairement qu'il s'agit de la valeur que l'admin GeoNature doit saisir dans son interface.

## Changement

- **`README.md`** : header de colonne passe de `Code de version` à `Code de version (à saisir côté admin GeoNature)`.
- **Body de la release GitHub `v1.0.0`** (hors diff, déjà appliqué via `gh release edit`) : même renommage du header de colonne.

`docs/VERSIONS.md` n'a pas de tableau de compat — la définition du champ est déjà explicite dans la section « Comment utiliser ce document ».

## Test plan

- [x] Preview de la release sur GitHub → header de colonne visible, compat table s'aligne correctement
- [ ] Preview du README sur la PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)