### PR TITLE
docs: warning explicite que le nom de l'APK doit matcher le chemin admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,12 @@ Pour que les utilisateurs soient notifiés des mises à jour, l'administrateur d
 
 2. **Déposer l'APK** (téléchargé depuis les releases GitHub) :
    ```bash
-   cp monitoring-x.y.z.apk <GEONATURE>/backend/media/mobile/monitoring/monitoring.apk
+   cp monitoring-v<X.Y.Z>-geonature-<M.m>.apk <GEONATURE>/backend/media/mobile/monitoring/monitoring.apk
    ```
+
+   > ⚠️ **Le nom du fichier sur le serveur doit correspondre EXACTEMENT au champ « Chemin relatif » de l'admin** (étape 3). L'app construit l'URL de téléchargement directement à partir de ce chemin — un nom différent → 404 → la mise à jour reste bloquée en chargement chez l'utilisateur.
+   >
+   > La convention est de renommer en `monitoring.apk` (URL stable d'une release à l'autre, le chemin admin ne change jamais — seul le **Code de version** est à incrémenter à chaque release).
 
 3. **Enregistrer l'application** dans l'admin GeoNature :
    - Aller dans **Administration > Autres > Applications mobiles**
@@ -151,7 +155,7 @@ Pour que les utilisateurs soient notifiés des mises à jour, l'administrateur d
 
    > ⚠️ **Code de version** : ne pas confondre avec le nom de version (`1.0.0`). C'est un entier strictement croissant, fixé à la compilation (buildNumber de `pubspec.yaml`), que l'admin doit saisir tel quel. L'app ne propose une mise à jour que si la valeur admin est **strictement supérieure** à celle de l'APK installé.
 
-4. **Mettre à jour** : lors d'une nouvelle version, remplacer l'APK et incrémenter le **Code de version** dans l'admin.
+4. **Mettre à jour** : lors d'une nouvelle version, **remplacer le fichier `monitoring.apk`** sur le serveur (en renommant le nouvel APK téléchargé) et incrémenter le **Code de version** dans l'admin. Le chemin relatif reste inchangé.
 
 L'application vérifie automatiquement au lancement et après chaque synchronisation si une mise à jour est disponible.
 


### PR DESCRIPTION
## Contexte

Symptôme rencontré post-release `v1.1.0` : l'admin a déposé l'APK sur le serveur GeoNature avec son nom versionné (`monitoring-v1.1.0-geonature-2.17.apk`) sans le renommer en `monitoring.apk`, alors que le champ « Chemin relatif » de l'admin était à `monitoring/monitoring.apk`. Résultat : 404 côté serveur et mise à jour bloquée en chargement chez l'utilisateur.

La doc actuelle mentionne le rename via un `cp ... monitoring.apk` dans une commande bash, mais c'est trop discret — le bash command rate son objectif documentaire.

## Changements

- Ajoute un callout `⚠️` explicite sous l'étape 2 : « le nom du fichier sur le serveur doit correspondre EXACTEMENT au champ Chemin relatif de l'admin ». Mentionne le symptôme (404 → chargement bloqué) pour aider au diagnostic.
- Explique pourquoi la convention `monitoring.apk` est utile : URL stable d'une release à l'autre, donc l'admin n'a qu'à incrémenter le Code de version, sans retoucher le chemin.
- Reformule l'étape 4 pour préciser que c'est bien `monitoring.apk` qu'on remplace, pas la ligne admin.
- Met à jour le placeholder `monitoring-x.y.z.apk` → `monitoring-v<X.Y.Z>-geonature-<M.m>.apk` pour coller au naming réel publié sur les releases GitHub.

## Test plan

- [ ] Relire le rendu Markdown sur GitHub pour vérifier que le callout `⚠️` se rend bien dans la liste numérotée

🤖 Generated with [Claude Code](https://claude.com/claude-code)