### PR TITLE
v1.1.1: carte sites modules sans groupes + perf onglet Sites + UX groupes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,12 @@ Pour que les utilisateurs soient notifiés des mises à jour, l'administrateur d
 
 2. **Déposer l'APK** (téléchargé depuis les releases GitHub) :
    ```bash
-   cp monitoring-x.y.z.apk <GEONATURE>/backend/media/mobile/monitoring/monitoring.apk
+   cp monitoring-v<X.Y.Z>-geonature-<M.m>.apk <GEONATURE>/backend/media/mobile/monitoring/monitoring.apk
    ```
+
+   > ⚠️ **Le nom du fichier sur le serveur doit correspondre EXACTEMENT au champ « Chemin relatif » de l'admin** (étape 3). L'app construit l'URL de téléchargement directement à partir de ce chemin — un nom différent → 404 → la mise à jour reste bloquée en chargement chez l'utilisateur.
+   >
+   > La convention est de renommer en `monitoring.apk` (URL stable d'une release à l'autre, le chemin admin ne change jamais — seul le **Code de version** est à incrémenter à chaque release).
 
 3. **Enregistrer l'application** dans l'admin GeoNature :
    - Aller dans **Administration > Autres > Applications mobiles**
@@ -151,7 +155,7 @@ Pour que les utilisateurs soient notifiés des mises à jour, l'administrateur d
 
    > ⚠️ **Code de version** : ne pas confondre avec le nom de version (`1.0.0`). C'est un entier strictement croissant, fixé à la compilation (buildNumber de `pubspec.yaml`), que l'admin doit saisir tel quel. L'app ne propose une mise à jour que si la valeur admin est **strictement supérieure** à celle de l'APK installé.
 
-4. **Mettre à jour** : lors d'une nouvelle version, remplacer l'APK et incrémenter le **Code de version** dans l'admin.
+4. **Mettre à jour** : lors d'une nouvelle version, **remplacer le fichier `monitoring.apk`** sur le serveur (en renommant le nouvel APK téléchargé) et incrémenter le **Code de version** dans l'admin. Le chemin relatif reste inchangé.
 
 L'application vérifie automatiquement au lancement et après chaque synchronisation si une mise à jour est disponible.
 

--- a/integration_test/scenarios/visit_stats_e2e_test.dart
+++ b/integration_test/scenarios/visit_stats_e2e_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gn_mobile_monitoring/data/db/database.dart';
 import 'package:integration_test/integration_test.dart';
@@ -30,7 +31,7 @@ void main() {
     });
 
     testWidgets(
-        'le tableau Sites affiche Dernier passage et Nb. passages par site, '
+        'la liste Sites affiche Dernier passage et Nb. passages par site, '
         'inclut les visites non téléversées', (tester) async {
       // Config module avec last_visit / nb_visits dans display_list
       await seeder.seedAll(siteDisplayList: [
@@ -128,27 +129,26 @@ void main() {
       moduleRobot.expectSite('Site de test Alpha');
       moduleRobot.expectSite('Site de test Beta');
 
-      // Headers des colonnes : un libellé venant de `predefinedLabels` est
-      // déjà rédigé proprement (cf. buildDataColumns dans detail_page.dart
-      // qui n'appelle pas `formatLabel` quand `labelFromConfig` est vrai),
-      // donc on attend la capitalisation française naturelle (Dernier
-      // passage / Nb. passages, pas le Title-Case anglais).
-      expect(find.text('Dernier passage'), findsOneWidget);
-      expect(find.text('Nb. passages'), findsOneWidget);
+      // Depuis le refactor de l'onglet Sites en ListView.builder, il n'y a
+      // plus de DataTable avec des entêtes de colonnes — les infos visites
+      // sont rendues sous forme de chips dans chaque Card. On vérifie donc
+      // le contenu des chips, pas des cellules.
 
-      // Alpha : 2 visites, dernière 20/03/2026. Beta : 1 visite, 10/02/2026.
+      // Dates de dernière visite (format dd/MM/yyyy identique à l'ancien rendu)
       expect(find.text('20/03/2026'), findsOneWidget,
           reason:
               'Dernière visite de Alpha (inclut la visite non téléversée)');
       expect(find.text('10/02/2026'), findsOneWidget,
           reason: 'Dernière visite de Beta');
-      expect(find.text('2'), findsOneWidget,
+      // Nb. passages — désormais affiché avec pluriel ("N passages" / "1 passage")
+      // dans la chip Icons.repeat de la Card.
+      expect(find.text('2 passages'), findsOneWidget,
           reason: 'Nb visites pour Alpha');
-      expect(find.text('1'), findsOneWidget,
+      expect(find.text('1 passage'), findsOneWidget,
           reason: 'Nb visites pour Beta');
     });
 
-    testWidgets('un site sans visite affiche 0 en Nb. passages',
+    testWidgets('un site sans visite ne montre aucune puce Nb. passages',
         (tester) async {
       await seeder.seedAll(siteDisplayList: [
         'base_site_name',
@@ -185,11 +185,18 @@ void main() {
         const Duration(seconds: 15),
       );
 
-      // Deux sites seedés, tous deux sans visite → chacun doit afficher '0'
-      // dans la cellule Nb. passages.
-      expect(find.text('0'), findsNWidgets(2),
+      // Depuis le refactor en ListView.builder, la Card de chaque site
+      // masque la chip nb_passages si la valeur est 0 (UX mobile : on
+      // évite la pollution visuelle). On vérifie donc que :
+      // 1. les 2 sites sont bien rendus
+      // 2. aucune chip Icons.repeat (compteur visites) n'est affichée
+      //    → l'absence implique 0
+      final moduleRobot = ModuleDetailRobot(tester);
+      moduleRobot.expectSite('Site de test Alpha');
+      moduleRobot.expectSite('Site de test Beta');
+      expect(find.byIcon(Icons.repeat), findsNothing,
           reason:
-              'Chaque site sans visite doit rendre 0 en Nb. passages');
+              'Aucun site n\'a de visite, donc pas de puce nb passages');
     });
   });
 }

--- a/lib/presentation/view/map/gen_map.dart
+++ b/lib/presentation/view/map/gen_map.dart
@@ -95,9 +95,13 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
     final mapState = ref.watch(mapViewModelProvider(_viewModelParams));
     final viewModel = ref.read(mapViewModelProvider(_viewModelParams).notifier);
 
-    // Fit bounds when features are loaded and not yet fitted
+    // Fit bounds when features are loaded and not yet fitted. Le check
+    // `mounted` dans le callback évite les crashes natifs si l'utilisateur
+    // pop la page avant que la frame suivante n'exécute le fitCamera (le
+    // mapController a alors été disposé).
     if (!_hasInitiallyFitBounds && mapState.hasFeatures && !mapState.isLoading) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
         _fitBoundsToFeatures(viewModel);
         _hasInitiallyFitBounds = true;
       });
@@ -774,19 +778,9 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
   }
 
   Widget _buildScrollableSitesList(List<BaseSite> sites) {
-    final scrollController = ScrollController();
-    return SizedBox(
-      height: 200,
-      child: Scrollbar(
-        controller: scrollController,
-        thumbVisibility: true,
-        child: SingleChildScrollView(
-          controller: scrollController,
-          child: Column(
-            children: sites.map((site) => _buildSiteListItem(site)).toList(),
-          ),
-        ),
-      ),
+    return _ScrollableSitesList(
+      sites: sites,
+      itemBuilder: _buildSiteListItem,
     );
   }
 
@@ -991,5 +985,54 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
         ),
       );
     }
+  }
+}
+
+/// Liste scrollable utilisée dans le popup d'un groupe de sites. Extraite
+/// en widget Stateful pour pouvoir disposer son `ScrollController` ; sans
+/// ça, chaque ouverture de popup laissait fuir un controller en mémoire.
+class _ScrollableSitesList extends StatefulWidget {
+  final List<BaseSite> sites;
+  final Widget Function(BaseSite site) itemBuilder;
+
+  const _ScrollableSitesList({
+    required this.sites,
+    required this.itemBuilder,
+  });
+
+  @override
+  State<_ScrollableSitesList> createState() => _ScrollableSitesListState();
+}
+
+class _ScrollableSitesListState extends State<_ScrollableSitesList> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 200,
+      child: Scrollbar(
+        controller: _scrollController,
+        thumbVisibility: true,
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          child: Column(
+            children: widget.sites.map(widget.itemBuilder).toList(),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/view/map/gen_map.dart
+++ b/lib/presentation/view/map/gen_map.dart
@@ -277,14 +277,25 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
   /// Fit map bounds to all features
   void _fitBoundsToFeatures(MapViewModel viewModel) {
     final bounds = viewModel.computeGlobalBounds();
-    if (bounds != null) {
-      mapController.fitCamera(
-        CameraFit.bounds(
-          bounds: LatLngBounds.fromPoints([bounds.southWest, bounds.northEast]),
-          padding: const EdgeInsets.all(40),
-        ),
-      );
+    if (bounds == null) return;
+
+    // Bounds dégénérée (un seul point unique, ou plusieurs sites tous aux
+    // mêmes coordonnées) → fitCamera calcule un zoom infini et l'assertion
+    // `zoom.isFinite` d'flutter_map fait crasher l'app nativement
+    // (tombstoned). On centre simplement la caméra sur ce point à un zoom
+    // raisonnable.
+    if (bounds.southWest.latitude == bounds.northEast.latitude &&
+        bounds.southWest.longitude == bounds.northEast.longitude) {
+      mapController.move(bounds.southWest, 15);
+      return;
     }
+
+    mapController.fitCamera(
+      CameraFit.bounds(
+        bounds: LatLngBounds.fromPoints([bounds.southWest, bounds.northEast]),
+        padding: const EdgeInsets.all(40),
+      ),
+    );
   }
 
   /// Build site markers from point features
@@ -359,7 +370,15 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
             width: 150,
             height: labelHeight,
             rotate: true,
-            child: _buildLabelContainer(labelText),
+            // Le label d'un groupe (polygone/polyline) n'avait pas de
+            // handler de tap — il bloquait visuellement la zone du polygone
+            // sans rien faire au clic. On l'aligne sur le comportement des
+            // markers points : tap → popup avec « Voir les détails ».
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _showFeaturePopup(context, centroid, feature),
+              child: _buildLabelContainer(labelText),
+            ),
           ),
         );
       }

--- a/lib/presentation/view/map/gen_map.dart
+++ b/lib/presentation/view/map/gen_map.dart
@@ -32,6 +32,12 @@ class GeometriesMapWidget extends ConsumerStatefulWidget {
   final ModuleInfo? moduleInfo;
   final SiteGroup? siteGroup;
 
+  /// Indique que les markers représentent des sites directement attachés au
+  /// module (cas où le module n'a pas de groupes). Sans ce flag, un `siteGroup`
+  /// nul signifie « markers = groupes de sites » — branchement par défaut
+  /// utilisé pour le popup et la navigation « Voir les détails ».
+  final bool isModuleSitesMap;
+
   const GeometriesMapWidget({
     super.key,
     required this.geojsonData,
@@ -41,6 +47,7 @@ class GeometriesMapWidget extends ConsumerStatefulWidget {
     this.customConfig,
     this.moduleInfo,
     this.siteGroup,
+    this.isModuleSitesMap = false,
   });
 
   @override
@@ -52,6 +59,14 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
   late final MapController mapController;
   List<Marker> userMarkers = [];
   bool _hasInitiallyFitBounds = false;
+
+  /// Vrai quand chaque marker correspond à un site (et non à un groupe) :
+  /// soit on est dans un groupe de sites (siteGroup non nul), soit le module
+  /// n'a pas de groupes du tout (isModuleSitesMap). Sans ce flag, un
+  /// `siteGroup == null` envoyait toujours « Voir les détails » vers la page
+  /// d'un groupe → erreur « Impossible de charger le groupe de sites ».
+  bool get _markersAreSites =>
+      widget.siteGroup != null || widget.isModuleSitesMap;
 
   @override
   void initState() {
@@ -608,7 +623,7 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
       });
     }
 
-    if (displayProperties.isEmpty && widget.siteGroup != null) {
+    if (displayProperties.isEmpty && _markersAreSites) {
       displayProperties.add(
         const Padding(
           padding: EdgeInsets.all(8.0),
@@ -633,7 +648,7 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
             children: [
               ...displayProperties,
               // Show sites count for site groups
-              if (widget.siteGroup == null && siteId != null)
+              if (!_markersAreSites && siteId != null)
                 _buildSiteGroupSitesList(context, siteId),
               // Action buttons
               if (siteId != null && widget.moduleInfo != null)
@@ -824,7 +839,7 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
 
   Widget _buildAddButton(
       BuildContext context, Map<String, dynamic> properties, int siteId) {
-    if (widget.siteGroup == null) {
+    if (!_markersAreSites) {
       // Site group context - add site button
       if (widget.moduleInfo!.module.complement?.configuration?.site != null) {
         return SizedBox(
@@ -865,7 +880,7 @@ class _GeometriesMapWidgetState extends ConsumerState<GeometriesMapWidget> {
 
   Future<void> _navigateToDetails(
       BuildContext context, Map<String, dynamic> properties, int siteId) async {
-    if (widget.siteGroup == null) {
+    if (!_markersAreSites) {
       // Navigate to site group details
       final groupId = properties['id'] as int?;
       if (groupId != null) {

--- a/lib/presentation/view/module/module_detail_page_base.dart
+++ b/lib/presentation/view/module/module_detail_page_base.dart
@@ -2465,186 +2465,23 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
     return null;
   }
 
+  /// Onglet Sites en ListView virtualisée. L'ancien `buildDataTable`
+  /// construisait les 1085 DataRow d'un coup → freeze ~300-500ms sur l'UI
+  /// thread, parfois jusqu'à l'ANR quand un second rebuild de la table
+  /// arrivait (stats de visites). `ListView.builder` ne construit que les
+  /// items visibles, l'ouverture est quasi-instantanée même à 5000+ sites.
   Widget _buildSitesTab() {
-    // Utiliser le module mis à jour s'il est disponible
     final module = _updatedModule ?? widget.moduleInfo.module;
-
-    // Obtenir la configuration des sites
     final siteConfig = module.complement?.configuration?.site;
+    final customConfig = module.complement?.configuration?.custom;
 
     if (_isLoadingSites && _displayedSites.isEmpty) {
       return const Center(child: CircularProgressIndicator());
     }
 
-    // Déterminer les colonnes à afficher pour les sites
-    List<String> standardColumns = [
-      'actions',
-      'base_site_name',
-      'base_site_code',
-      'base_site_description'
-    ];
-
-    // BaseSite n'a pas de propriété 'data' directement, nous devons donc éviter d'y accéder
-    Map<String, dynamic>? firstItemData;
-
-    List<String> displayColumns = determineDataColumns(
-      standardColumns: standardColumns,
-      itemConfig: siteConfig,
-      firstItemData: firstItemData,
-      filterMetaColumns: true,
-    );
-
-    // Créer les colonnes du DataTable
-    List<DataColumn> columns = buildDataColumns(
-      columns: displayColumns,
-      itemConfig: siteConfig,
-      predefinedLabels: {
-        'actions': 'Action',
-        'base_site_name': 'Nom',
-        'base_site_code': 'Code',
-        'base_site_description': 'Description',
-        'altitude_min': 'Altitude min',
-        'altitude_max': 'Altitude max',
-        'last_visit': 'Dernier passage',
-        'nb_visits': 'Nb. passages',
-      },
-    );
-
-    // Générer le schéma pour le formatage des cellules
-    Map<String, dynamic> schema = {};
-    if (siteConfig != null) {
-      schema = FormConfigParser.generateUnifiedSchema(siteConfig, customConfig);
-    }
-
-    // Construire les lignes du tableau
-    List<DataRow> rows = _displayedSites.map((site) {
-      return DataRow(
-        cells: displayColumns.map((column) {
-          // Colonne d'actions
-          if (column == 'actions') {
-            final hasUnsyncedVisits = _unsyncedSiteIds.contains(site.idBaseSite);
-            return DataCell(
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.visibility, size: 20),
-                    onPressed: () async {
-                      await Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => SiteDetailPage(
-                            site: site,
-                            moduleInfo: _updatedModule != null
-                                ? widget.moduleInfo
-                                    .copyWith(module: _updatedModule!)
-                                : widget.moduleInfo,
-                          ),
-                        ),
-                      );
-                      // L'utilisateur a pu créer/synchroniser une visite sur
-                      // ce site ; on rafraîchit le badge et les stats au
-                      // retour pour que "Dernier passage" / "Nb. passages"
-                      // reflètent la saisie immédiatement.
-                      if (mounted) _loadVisitDerivedData();
-                    },
-                    constraints: const BoxConstraints(
-                      minWidth: 36,
-                      minHeight: 36,
-                    ),
-                  ),
-                  if (hasUnsyncedVisits)
-                    Tooltip(
-                      message: 'Saisies locales non téléversées',
-                      child: Container(
-                        width: 10,
-                        height: 10,
-                        margin: const EdgeInsets.only(left: 2),
-                        decoration: const BoxDecoration(
-                          color: Colors.orange,
-                          shape: BoxShape.circle,
-                        ),
-                      ),
-                    ),
-                ],
-              ),
-            );
-          }
-
-          // Propriétés standard du site
-          dynamic value;
-          switch (column) {
-            case 'base_site_name':
-              value = site.baseSiteName;
-              break;
-            case 'base_site_code':
-              value = site.baseSiteCode;
-              break;
-            case 'base_site_description':
-              value = site.baseSiteDescription;
-              break;
-            case 'altitude_min':
-              value = site.altitudeMin;
-              break;
-            case 'altitude_max':
-              value = site.altitudeMax;
-              break;
-            case 'last_visit':
-              // Calculé localement depuis t_base_visits : prend en compte
-              // les saisies offline pas encore téléversées, contrairement
-              // au last_visit serveur. Formaté "dd/MM/yyyy" ici car la
-              // config `site` ne déclare généralement pas la colonne dans
-              // `generic`, donc formatDataCellValue n'a pas le type_widget
-              // `date` pour la formater elle-même.
-              final lastVisit =
-                  _visitStatsBySiteId[site.idBaseSite]?.lastVisit;
-              value = lastVisit != null
-                  ? '${lastVisit.day.toString().padLeft(2, '0')}/'
-                      '${lastVisit.month.toString().padLeft(2, '0')}/'
-                      '${lastVisit.year}'
-                  : null;
-              break;
-            case 'nb_visits':
-              value = _visitStatsBySiteId[site.idBaseSite]?.nbVisits ?? 0;
-              break;
-            default:
-              // Colonne inconnue ou non encore exploitée (ex. "visitors",
-              // "comments" côté server complement → issue dédiée).
-              value = null;
-          }
-
-          // Formater la valeur et créer la cellule
-          String displayValue = formatDataCellValue(
-            rawValue: value,
-            columnName: column,
-            schema: schema,
-          );
-
-          return buildFormattedDataCell(
-            value: displayValue,
-            enableTooltip: true,
-          );
-        }).toList(),
-      );
-    }).toList();
-
-    // Message vide personnalisé
-    Widget emptyMessage = Padding(
-      padding: const EdgeInsets.symmetric(vertical: 16.0),
-      child: Text(
-        'Aucun site associé à ce module',
-        style: TextStyle(
-          fontSize: 16,
-          color: AppColors.hint,
-        ),
-      ),
-    );
-
-    // Bouton d'ajout de site si éditable
     Widget? addButton;
     final isEditable = _isSiteEditableOnField(siteConfig);
     if (isEditable && siteConfig != null) {
-      final customConfig = module.complement?.configuration?.custom;
       final currentModuleInfo = _updatedModule != null
           ? widget.moduleInfo.copyWith(module: _updatedModule!)
           : widget.moduleInfo;
@@ -2662,27 +2499,205 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
               ),
             ),
           );
-          // Recharger les sites après retour du formulaire
-          if (mounted) {
-            loadCompleteModule();
-          }
+          if (mounted) loadCompleteModule();
         },
         icon: const Icon(Icons.add_circle),
         tooltip: 'Ajouter un ${siteConfig.label ?? 'site'}',
       );
     }
 
-    // Utiliser notre méthode factorisée buildDataTable
-    return buildDataTable(
-      columns: columns,
-      rows: rows,
-      showSearch: true,
-      searchHint: "Rechercher un site",
-      searchController: _searchController,
-      onSearchChanged: _handleSearch,
-      headerActions: addButton,
-      emptyMessage: emptyMessage,
-      isLoading: _isLoadingSites,
+    return Column(
+      children: [
+        // Recherche + bouton ajout
+        Padding(
+          padding: const EdgeInsets.fromLTRB(8, 8, 8, 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _searchController,
+                  onChanged: _handleSearch,
+                  decoration: const InputDecoration(
+                    hintText: 'Rechercher un site',
+                    prefixIcon: Icon(Icons.search),
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                ),
+              ),
+              if (addButton != null) addButton,
+            ],
+          ),
+        ),
+        // Compteur de résultats — utile quand on filtre dans 1000+ sites
+        if (_allSites.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(left: 12, right: 12, bottom: 4),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                _searchQuery.isEmpty
+                    ? '${_displayedSites.length} site${_displayedSites.length > 1 ? 's' : ''}'
+                    : '${_displayedSites.length} / ${_allSites.length} site${_allSites.length > 1 ? 's' : ''}',
+                style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+              ),
+            ),
+          ),
+        Expanded(
+          child: _displayedSites.isEmpty
+              ? Center(
+                  child: Text(
+                    _allSites.isEmpty
+                        ? 'Aucun site associé à ce module'
+                        : 'Aucun site ne correspond à la recherche',
+                    style: TextStyle(fontSize: 16, color: AppColors.hint),
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: _displayedSites.length,
+                  itemBuilder: (context, index) {
+                    final site = _displayedSites[index] as BaseSite;
+                    return _buildSiteCard(site);
+                  },
+                ),
+        ),
+      ],
     );
+  }
+
+  Widget _buildSiteCard(BaseSite site) {
+    final hasUnsyncedVisits = _unsyncedSiteIds.contains(site.idBaseSite);
+    final stats = _visitStatsBySiteId[site.idBaseSite];
+    final title =
+        site.baseSiteName ?? site.baseSiteCode ?? 'Site ${site.idBaseSite}';
+    final showCode =
+        site.baseSiteCode != null && site.baseSiteCode != site.baseSiteName;
+
+    final chips = <Widget>[];
+    final altitudeText =
+        _formatAltitudeRange(site.altitudeMin, site.altitudeMax);
+    if (altitudeText != null) {
+      chips.add(_buildSiteInfoChip(Icons.terrain, altitudeText));
+    }
+    final lastVisit = stats?.lastVisit;
+    if (lastVisit != null) {
+      chips.add(_buildSiteInfoChip(
+        Icons.event,
+        '${lastVisit.day.toString().padLeft(2, '0')}/'
+            '${lastVisit.month.toString().padLeft(2, '0')}/${lastVisit.year}',
+      ));
+    }
+    final nbVisits = stats?.nbVisits ?? 0;
+    if (nbVisits > 0) {
+      chips.add(_buildSiteInfoChip(
+        Icons.repeat,
+        '$nbVisits passage${nbVisits > 1 ? 's' : ''}',
+      ));
+    }
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: InkWell(
+        onTap: () async {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => SiteDetailPage(
+                site: site,
+                moduleInfo: _updatedModule != null
+                    ? widget.moduleInfo.copyWith(module: _updatedModule!)
+                    : widget.moduleInfo,
+              ),
+            ),
+          );
+          // L'utilisateur a pu créer/synchroniser une visite — on
+          // rafraîchit les stats au retour pour que « Dernier passage » /
+          // « Nb. passages » reflètent la saisie immédiatement.
+          if (mounted) _loadVisitDerivedData();
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                          fontWeight: FontWeight.w600, fontSize: 15),
+                    ),
+                    if (showCode)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: Text(
+                          site.baseSiteCode!,
+                          style: TextStyle(
+                              fontSize: 12, color: Colors.grey[600]),
+                        ),
+                      ),
+                    if (site.baseSiteDescription != null &&
+                        site.baseSiteDescription!.trim().isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          site.baseSiteDescription!,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                      ),
+                    if (chips.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Wrap(
+                          spacing: 10,
+                          runSpacing: 4,
+                          children: chips,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              if (hasUnsyncedVisits)
+                Tooltip(
+                  message: 'Saisies locales non téléversées',
+                  child: Container(
+                    width: 10,
+                    height: 10,
+                    margin: const EdgeInsets.symmetric(horizontal: 6),
+                    decoration: const BoxDecoration(
+                      color: Colors.orange,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              const Icon(Icons.chevron_right, color: Colors.grey),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSiteInfoChip(IconData icon, String text) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 13, color: Colors.grey[600]),
+        const SizedBox(width: 3),
+        Text(text, style: TextStyle(fontSize: 11, color: Colors.grey[700])),
+      ],
+    );
+  }
+
+  String? _formatAltitudeRange(int? min, int? max) {
+    if (min == null && max == null) return null;
+    if (min == null) return '≤ ${max}m';
+    if (max == null) return '≥ ${min}m';
+    if (min == max) return '${min}m';
+    return '$min–${max}m';
   }
 }

--- a/lib/presentation/view/module/module_detail_page_base.dart
+++ b/lib/presentation/view/module/module_detail_page_base.dart
@@ -1569,10 +1569,32 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
             title: Row(
               children: [
                 Expanded(
-                  child: _buildGroupTitle(
-                    group,
-                    sitesGroupConfig,
-                    parsedGroupConfig,
+                  // Tap sur le titre → ouvre directement la page du groupe.
+                  // Sans ça, le titre ne servait qu'à déplier l'ExpansionTile
+                  // (peu utile pour les groupes sans sites où l'expansion ne
+                  // montre que les propriétés). L'icône œil reste accessible
+                  // dans `leading` pour la même action.
+                  child: InkWell(
+                    onTap: () async {
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => SiteGroupDetailPage(
+                            siteGroup: group,
+                            moduleInfo: _updatedModule != null
+                                ? widget.moduleInfo
+                                    .copyWith(module: _updatedModule!)
+                                : widget.moduleInfo,
+                          ),
+                        ),
+                      );
+                      if (mounted) _loadVisitDerivedData();
+                    },
+                    child: _buildGroupTitle(
+                      group,
+                      sitesGroupConfig,
+                      parsedGroupConfig,
+                    ),
                   ),
                 ),
                 // Afficher la distance à droite
@@ -1948,7 +1970,21 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
         _cachedGroups ?? _filteredSiteGroups.whereType<SiteGroup>().toList();
 
     return FloatingActionButton(
-      onPressed: () {
+      onPressed: () async {
+        // Pour les groupes sans geom propre, on dérive un centroïde depuis
+        // leurs sites (s'ils en ont) — sinon ils étaient invisibles sur la
+        // carte et donc inaccessibles. Loader dialog pendant les requêtes
+        // DB qui peuvent prendre quelques centaines de ms si beaucoup de
+        // groupes sont à augmenter.
+        showDialog(
+          context: context,
+          barrierDismissible: false,
+          builder: (_) => const Center(child: CircularProgressIndicator()),
+        );
+        final augmented =
+            await _augmentGroupsWithFallbackCentroids(groupsToDisplay);
+        if (!mounted) return;
+        Navigator.of(context).pop();
         Navigator.push(
           context,
           MaterialPageRoute(
@@ -1959,7 +1995,7 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
                 ),
               ),
               body: GeometriesMapWidget(
-                geojsonData: _convertSiteGroupsToGeoJSON(groupsToDisplay),
+                geojsonData: _convertSiteGroupsToGeoJSON(augmented),
                 displayList: sitesGroupConfig?.displayList ??
                     sitesGroupConfig?.displayProperties,
                 siteConfig: null, // Pas de siteConfig pour les groupes
@@ -1974,6 +2010,92 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
       tooltip: 'Afficher la carte des groupes de sites',
       child: const Icon(Icons.map, color: Colors.white),
     );
+  }
+
+  /// Pour chaque groupe sans `geom` propre, on essaie de calculer un
+  /// centroïde à partir des géométries de ses sites. Si on y arrive, on
+  /// renvoie un clone du groupe avec un geom Point synthétique → il devient
+  /// visible et cliquable sur la carte. Sinon (groupe sans sites positionnés
+  /// non plus) on garde le groupe tel quel — il sera filtré dans
+  /// `_convertSiteGroupsToGeoJSON`, donc absent de la carte mais toujours
+  /// accessible via l'onglet Groupes.
+  Future<List<SiteGroup>> _augmentGroupsWithFallbackCentroids(
+      List<SiteGroup> groups) async {
+    if (widget.ref == null) return groups;
+    final sitesDatabase = widget.ref!.read(siteDatabaseProvider);
+    final moduleId = (_updatedModule ?? widget.moduleInfo.module).id;
+
+    final result = <SiteGroup>[];
+    for (final group in groups) {
+      if (group.geom != null && group.geom!.isNotEmpty) {
+        result.add(group);
+        continue;
+      }
+      try {
+        final sites = await sitesDatabase.getSitesBySiteGroupAndModule(
+            group.idSitesGroup, moduleId);
+        final centroid = _centroidFromSites(sites);
+        if (centroid != null) {
+          // Synthèse d'un geom Point en GeoJSON (lon, lat).
+          final syntheticGeom = jsonEncode({
+            'type': 'Point',
+            'coordinates': [centroid.longitude, centroid.latitude],
+          });
+          result.add(group.copyWith(geom: syntheticGeom));
+        } else {
+          result.add(group);
+        }
+      } catch (e) {
+        debugPrint(
+            'Erreur calcul centroïde groupe ${group.idSitesGroup}: $e');
+        result.add(group);
+      }
+    }
+    return result;
+  }
+
+  /// Moyenne arithmétique des positions des sites — suffisant pour un point
+  /// indicatif. Parse les geoms Point/LineString/Polygon et prend le premier
+  /// point de chaque (centroïde géométrique exact pas nécessaire ici).
+  LatLng? _centroidFromSites(List<BaseSite> sites) {
+    double sumLat = 0;
+    double sumLng = 0;
+    int count = 0;
+    for (final site in sites) {
+      if (site.geom == null || site.geom!.isEmpty) continue;
+      try {
+        final geom = jsonDecode(site.geom!) as Map<String, dynamic>;
+        final coords = geom['coordinates'];
+        double? lat;
+        double? lng;
+        switch (geom['type']) {
+          case 'Point':
+            lng = (coords[0] as num).toDouble();
+            lat = (coords[1] as num).toDouble();
+            break;
+          case 'LineString':
+            final first = (coords as List).first;
+            lng = (first[0] as num).toDouble();
+            lat = (first[1] as num).toDouble();
+            break;
+          case 'Polygon':
+            final firstRing = (coords as List).first as List;
+            final first = firstRing.first;
+            lng = (first[0] as num).toDouble();
+            lat = (first[1] as num).toDouble();
+            break;
+        }
+        if (lat != null && lng != null) {
+          sumLat += lat;
+          sumLng += lng;
+          count++;
+        }
+      } catch (_) {
+        // geom invalide, on saute
+      }
+    }
+    if (count == 0) return null;
+    return LatLng(sumLat / count, sumLng / count);
   }
 
   /// FAB carte pour les modules qui n'ont que des sites (pas de groupes).

--- a/lib/presentation/view/module/module_detail_page_base.dart
+++ b/lib/presentation/view/module/module_detail_page_base.dart
@@ -688,17 +688,25 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
   void _loadInitialSites() {
     setState(() {
       _isLoadingSites = true;
+    });
+    // Repousser la construction des DataRow d'une frame : pour les gros
+    // modules (1000+ sites) buildDataTable bloque ~300-500ms le thread UI,
+    // sans ce yield le spinner n'a pas le temps de peindre — l'utilisateur
+    // ne voit qu'un écran figé.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        // L'onglet Sites liste TOUS les sites du module (cohérent avec le
+        // comportement GeoNature web où l'onglet Sites affiche les 156 points
+        // du module plaquesreptiles, et pas seulement les sites hors groupe).
+        // Les orphelins servent uniquement à forcer l'AJOUT de l'onglet quand
+        // la config serveur ne le déclare pas — voir _updateChildrenTypesFromConfig.
+        final module = _updatedModule ?? widget.moduleInfo.module;
+        _allSites = module.sites ?? [];
+        _filterSites();
 
-      // L'onglet Sites liste TOUS les sites du module (cohérent avec le
-      // comportement GeoNature web où l'onglet Sites affiche les 156 points
-      // du module plaquesreptiles, et pas seulement les sites hors groupe).
-      // Les orphelins servent uniquement à forcer l'AJOUT de l'onglet quand
-      // la config serveur ne le déclare pas — voir _updateChildrenTypesFromConfig.
-      final module = _updatedModule ?? widget.moduleInfo.module;
-      _allSites = module.sites ?? [];
-      _filterSites();
-
-      _isLoadingSites = false;
+        _isLoadingSites = false;
+      });
     });
   }
 
@@ -840,7 +848,27 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           buildBreadcrumb(),
-          if (isMixedMode)
+          // Pendant `loadCompleteModule` (récup module + sites depuis la DB),
+          // _childrenTypes est vide → l'ancien build retombait sur
+          // buildBaseContent (juste les propriétés) sans feedback visuel : sur
+          // un gros module (1000+ sites) ça donnait l'impression d'un freeze.
+          if (_isInitialLoading)
+            const Expanded(
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CircularProgressIndicator(),
+                    SizedBox(height: 12),
+                    Text(
+                      'Chargement du module…',
+                      style: TextStyle(fontWeight: FontWeight.w500),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          else if (isMixedMode)
             Expanded(
               child: Column(
                 children: [
@@ -871,7 +899,11 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
             Expanded(child: buildBaseContent()),
         ],
       ),
-      floatingActionButton: hasSiteGroups ? _buildGroupsMapButton() : null,
+      // Bouton carte : groupes si dispo (priorité), sinon sites pour les
+      // modules sans groupes (endpoint serveur en 403 ou simplement vide).
+      floatingActionButton: hasSiteGroups
+          ? _buildGroupsMapButton()
+          : (hasSite ? _buildSitesMapButton() : null),
     );
   }
 
@@ -1942,6 +1974,99 @@ class ModuleDetailPageBaseState extends DetailPageState<ModuleDetailPageBase>
       tooltip: 'Afficher la carte des groupes de sites',
       child: const Icon(Icons.map, color: Colors.white),
     );
+  }
+
+  /// FAB carte pour les modules qui n'ont que des sites (pas de groupes).
+  /// Réutilise [GeometriesMapWidget] tel quel — le flux GeoJSON string →
+  /// MapViewModel parse est celui qui marche pour les cartes de groupes.
+  Widget _buildSitesMapButton() {
+    final module = _updatedModule ?? widget.moduleInfo.module;
+    final ObjectConfig? siteConfig = module.complement?.configuration?.site;
+    final CustomConfig? customConfig = module.complement?.configuration?.custom;
+
+    final List<BaseSite> sitesToDisplay =
+        _allSites.whereType<BaseSite>().toList();
+
+    return FloatingActionButton(
+      onPressed: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => Scaffold(
+              appBar: AppBar(
+                title: Text(
+                  'Carte des ${siteConfig?.label ?? 'sites'}',
+                ),
+              ),
+              body: GeometriesMapWidget(
+                geojsonData: _convertSitesToGeoJSON(sitesToDisplay),
+                displayList:
+                    siteConfig?.displayList ?? siteConfig?.displayProperties,
+                siteConfig: siteConfig,
+                customConfig: customConfig,
+                moduleInfo: _updatedModule != null
+                    ? widget.moduleInfo.copyWith(module: _updatedModule!)
+                    : widget.moduleInfo,
+                siteGroup: null,
+                isModuleSitesMap: true,
+              ),
+            ),
+          ),
+        );
+      },
+      tooltip: 'Afficher la carte des sites',
+      child: const Icon(Icons.map, color: Colors.white),
+    );
+  }
+
+  /// Convertit une liste de BaseSite en GeoJSON pour GeometriesMapWidget.
+  String? _convertSitesToGeoJSON(List<BaseSite> sites) {
+    if (sites.isEmpty) return null;
+
+    final List<Map<String, dynamic>> geoJsonFeatures = [];
+
+    for (final site in sites) {
+      if (site.geom == null || site.geom!.isEmpty) continue;
+
+      try {
+        final Map<String, dynamic> geometry = jsonDecode(site.geom!);
+
+        final feature = <String, dynamic>{
+          'id': site.idBaseSite,
+          'name': site.baseSiteName ?? 'Site ${site.idBaseSite}',
+          'description': site.baseSiteDescription ?? '',
+          'geom': geometry,
+        };
+
+        if (site.baseSiteCode != null) {
+          feature['base_site_code'] = site.baseSiteCode;
+        }
+        if (site.baseSiteName != null) {
+          feature['base_site_name'] = site.baseSiteName;
+        }
+        if (site.baseSiteDescription != null) {
+          feature['base_site_description'] = site.baseSiteDescription;
+        }
+        if (site.firstUseDate != null) {
+          feature['first_use_date'] = site.firstUseDate!.toString();
+        }
+        if (site.altitudeMin != null) {
+          feature['altitude_min'] = site.altitudeMin;
+        }
+        if (site.altitudeMax != null) {
+          feature['altitude_max'] = site.altitudeMax;
+        }
+
+        geoJsonFeatures.add(feature);
+      } catch (e) {
+        debugPrint(
+            'Erreur parsing geometry pour site ${site.idBaseSite}: $e');
+      }
+    }
+
+    if (geoJsonFeatures.isEmpty) return null;
+
+    return jsonEncode(geoJsonFeatures);
   }
 
   /// Convertit une liste de SiteGroup en format GeoJSON pour GeometriesMapWidget

--- a/lib/presentation/view/site_group_detail_page.dart
+++ b/lib/presentation/view/site_group_detail_page.dart
@@ -854,7 +854,15 @@ class _SiteGroupDetailPageState extends ConsumerState<SiteGroupDetailPage> {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
+      // Pas de FAB carte si le groupe ne contient aucun site : ouvrir une
+      // carte vide centrée par défaut (Paris ou GPS) sans aucun marker est
+      // confusant. Le FAB réapparaîtra automatiquement dès qu'un site est
+      // ajouté au groupe. Pendant le chargement, on cache aussi par défaut.
+      floatingActionButton: sitesState.maybeWhen(
+            data: (sites) => sites.isNotEmpty,
+            orElse: () => false,
+          )
+          ? FloatingActionButton(
         onPressed: () {
           Navigator.push(
             context,
@@ -940,7 +948,8 @@ class _SiteGroupDetailPageState extends ConsumerState<SiteGroupDetailPage> {
           );
         },
         child: const Icon(Icons.map),
-      ),
+      )
+          : null,
     );
   }
 

--- a/lib/presentation/viewmodel/map_viewmodel.dart
+++ b/lib/presentation/viewmodel/map_viewmodel.dart
@@ -46,9 +46,15 @@ class MapViewModelParams {
   int get hashCode => geoJsonData.hashCode;
 }
 
-/// Provider pour le MapViewModel
-final mapViewModelProvider =
-    StateNotifierProvider.family<MapViewModel, MapState, MapViewModelParams>(
+/// Provider pour le MapViewModel.
+///
+/// `.autoDispose` est critique : sans ça Riverpod garde l'instance en cache
+/// indéfiniment, et `_positionSubscription` (watchPosition GPS continu) ne
+/// se cancel jamais même après que l'utilisateur quitte la carte. Chaque
+/// ouverture accumulait une souscription supplémentaire — ANR garanti
+/// après quelques aller-retours liste modules ↔ carte.
+final mapViewModelProvider = StateNotifierProvider.autoDispose
+    .family<MapViewModel, MapState, MapViewModelParams>(
   (ref, params) {
     final loadMapFeaturesUseCase = ref.watch(loadMapFeaturesUseCaseProvider);
     final loadMapTileLayersUseCase = ref.watch(loadMapTileLayersUseCaseProvider);

--- a/lib/presentation/viewmodel/map_viewmodel.dart
+++ b/lib/presentation/viewmodel/map_viewmodel.dart
@@ -188,6 +188,13 @@ class MapViewModel extends StateNotifier<MapState> {
         );
       }
 
+      // L'utilisateur peut avoir pop la page pendant le `await execute()`
+      // initial. Sans ce guard, on s'abonne quand même au stream GPS et le
+      // listener orphelin n'est jamais cancel (dispose a déjà tourné). Avec
+      // .autoDispose ça arrive à chaque navigation rapide → fuite cumulative
+      // qui peut converger vers une saturation du receiver natif.
+      if (!_mounted) return;
+
       // Démarrer le tracking en continu
       _positionSubscription =
           _getUserLocationUseCase.watchPosition().listen((result) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+2
+version: 1.1.1+3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary

Version **1.1.1** : correctifs cartes + perf + UX, suite aux retours sur le module NICHOIRS de la LPO (1085 sites sans groupes).

### Correctifs cartes
- **Carte des sites pour les modules sans groupes** : un bouton flottant carte apparaît désormais aussi quand un module a uniquement des sites (cas où le serveur renvoie 403 sur `/sites_groups`). Avant : aucun moyen d'accéder à la carte.
- **Crash natif `Camera 'zoom' must be finite`** corrigé sur les groupes mono-site (bounds dégénérés → fitCamera infini).
- **Noms de groupes cliquables sur la carte** : les labels (`MarkerLayer` des centroïdes) déclenchent maintenant le popup détail au tap, alignés sur les markers points.
- **Centroïde dérivé des sites** quand un groupe n'a pas de `geom` propre : un marker indicatif apparaît si le groupe contient au moins un site positionné.
- **Bouton carte caché** sur un groupe sans sites (avant : ouvrait une carte vide centrée sur Paris).
- **Popup site correctement routé** : « Voir les détails » → `SiteDetailPage`, bouton « Ajouter une visite » fonctionnel.

### Performances
- **Onglet Sites virtualisé** (`DataTable` → `ListView.builder`) : ouverture quasi-instantanée même sur 1000+ sites. Avant : ~300-500 ms de freeze, parfois proche de l'ANR avec le second rebuild après chargement des stats visites.
- **MapViewModel en `.autoDispose`** : les souscriptions GPS continues étaient persistées éternellement et s'accumulaient à chaque cycle « modules → carte → retour ». Combiné à un guard `mounted` avant l'abonnement au stream pour éviter les listeners orphelins post-dispose.
- **Loader « Chargement du module… »** centré pendant la requête DB initiale.
- **Cleanup `ScrollController`** du popup groupe (extrait en StatefulWidget) qui fuitait à chaque ouverture.

### UX onglet Groupes
- **Tap sur le titre d'un groupe** ouvre directement la page du groupe. Avant : seul le petit œil 👁️ ouvrait, le titre ne servait qu'à déplier l'ExpansionTile (peu utile pour les groupes sans sites).

## Test plan

- [x] `flutter analyze` propre
- [x] E2E mock scenarios sur Pixel 6a : **31/31 passent** (`flutter test integration_test/scenarios/ --exclude-tags=map`)
- [x] E2E real-API sur Pixel 6a avec GeoNature local : **12/12 passent** (3 skips intentionnels préexistants ; un test re-run pour confirmer flakiness real-API, pas un bug)
- [x] Test mis à jour : `visit_stats_e2e_test.dart` adapté aux chips de Card au lieu des cellules de table
- [x] APK release `monitoring-v1.1.1-geonature-2.17.apk` (73 MB) envoyée à Julien pour validation sur son GeoNature
- [ ] Retour OK du testeur Julien
- [ ] Tag `v1.1.1-geonature-2.17` + GitHub Release après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)